### PR TITLE
Update gjk.c

### DIFF
--- a/gjk.c
+++ b/gjk.c
@@ -111,7 +111,7 @@ int gjk (const vec2 * vertices1, size_t count1,
     if (dotProduct (a, d) <= 0)
         return 0; // no collision
     
-    d = negate (d); // we will be searching in the opposite direction next
+    d = negate (a); // The next search direction is always towards the origin, so the next search direction is negate(a)
     
     while (1) {
         


### PR DESCRIPTION
The pseudo-code from [Wikipedia](https://en.wikipedia.org/wiki/Gilbert%E2%80%93Johnson%E2%80%93Keerthi_distance_algorithm), shows that the `d` should be the result of `negate(a)` in order to search towards the origin for convergence, not that it matters.